### PR TITLE
Change method to use strings.TrimRight

### DIFF
--- a/pkgmngr/pkgmngr.go
+++ b/pkgmngr/pkgmngr.go
@@ -69,7 +69,7 @@ func getPkgName(pkgURL string) string {
 
 	splitAddress := strings.Split(pkgURL, "/")
 	gitPkgName := splitAddress[len(splitAddress)-1]
-	pkgName := strings.Replace(gitPkgName, ".git", "", -1)
+	pkgName := strings.TrimRight(gitPkgName, ".git")
 	return pkgName
 }
 

--- a/pkgmngr/pkgmngr.go
+++ b/pkgmngr/pkgmngr.go
@@ -69,7 +69,7 @@ func getPkgName(pkgURL string) string {
 
 	splitAddress := strings.Split(pkgURL, "/")
 	gitPkgName := splitAddress[len(splitAddress)-1]
-	pkgName := strings.Split(gitPkgName, ".")[0]
+	pkgName := strings.Replace(gitPkgName, ".git", "", -1)
 	return pkgName
 }
 


### PR DESCRIPTION
Instead of splitting on the `.`, this change will just remove the trailing `.git` from the package name thus preserving the original package name in instances like `coc.nvim.git` or any other package name containing a `.`.