### PR TITLE
Add reinstall option

### DIFF
--- a/cmd/pkgs.go
+++ b/cmd/pkgs.go
@@ -37,6 +37,30 @@ var installPkgCmd = &cobra.Command{
 	},
 }
 
+// ReinstallPkgCmd represents the command for installing vim packages
+var reinstallPkgCmd = &cobra.Command{
+	Use:           "reinstall [pkg url]",
+	Short:         "reinstall a vim package",
+	Long:          "Use when the package cannot update with a simple pull",
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			cmd.Help()
+			return nil
+		}
+
+		for _, pkgName := range args {
+			fmt.Println("Reinstalling " + pkgName)
+			err := pkgmngr.Reinstall(pkgName)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
 // removePkgCmd represents the command for removing vim packages
 var removePkgCmd = &cobra.Command{
 	Use:           "rm [pkg name]",
@@ -88,7 +112,8 @@ var updatePkgCmd = &cobra.Command{
 			fmt.Println("Updating " + pkgName)
 			wasUpToDate, err := pkgmngr.Update(pkgName)
 			if err != nil {
-				if strings.Contains(err.Error(), "object not found") {
+				if strings.Contains(err.Error(), "object not found") ||
+					strings.Contains(err.Error(), "ssh: handshake failed: knownhosts: key mismatch") {
 					fmt.Println(err.Error())
 					continue
 				}
@@ -125,6 +150,7 @@ var listPkgCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(installPkgCmd)
+	rootCmd.AddCommand(reinstallPkgCmd)
 	rootCmd.AddCommand(removePkgCmd)
 	rootCmd.AddCommand(updatePkgCmd)
 	rootCmd.AddCommand(listPkgCmd)

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -22,6 +22,22 @@ func Clone(pkgURL, dirPath string) error {
 	return err
 }
 
+// RemoteURL returns the fetch URL. Always assumes remote name is 'origin'
+func RemoteURL(dirPath string) (string, error) {
+	repo, err := git.PlainOpen(dirPath)
+	if err != nil {
+		return "", err
+	}
+
+	// always assume origin
+	remote, err := repo.Remote("origin")
+	if err != nil {
+		return "", err
+	}
+
+	return remote.Config().URLs[0], nil
+}
+
 // Pull the latest changes from the remote repository of the directory given
 func Pull(dirPath string) error {
 	repo, err := git.PlainOpen(dirPath)


### PR DESCRIPTION
Add ability to reinstall a package with the name alone, no longer requiring a full URL

Adds a function to discover the remoteURL of repo, although it always assumes the name of the remote is 'origin'. I did this because we can either return an arbitrary list of remotes and then select the first one from the list, or do some deeper introspection of each remote, or just use what is the default behavior for most git remotes.

At some point, this should be configurable, but that may be an overoptimization.